### PR TITLE
Don't re-send the display list every time. Just generate frames

### DIFF
--- a/wrench/src/wrench.rs
+++ b/wrench/src/wrench.rs
@@ -322,6 +322,12 @@ impl Wrench {
                                        auxiliary_lists);
     }
 
+    pub fn refresh(&mut self) {
+        self.frame_start_sender.push(time::SteadyTime::now());
+
+        self.api.generate_frame();
+    }
+
     pub fn render(&mut self) {
         self.renderer.update();
         self.renderer.render(self.window_size);

--- a/wrench/src/yaml_frame_reader.rs
+++ b/wrench/src/yaml_frame_reader.rs
@@ -282,12 +282,15 @@ impl WrenchThing for YamlFrameReader {
             self.built_aux_data = Some(aux_builder.finalize());
 
             self.frame_built = true;
+
+            wrench.send_lists(self.frame_count,
+                              self.built_data.as_ref().unwrap().clone(),
+                              self.built_aux_data.as_ref().unwrap().clone());
+        } else {
+            wrench.refresh();
         }
 
         self.frame_count += 1;
-        wrench.send_lists(self.frame_count,
-                          self.built_data.as_ref().unwrap().clone(),
-                          self.built_aux_data.as_ref().unwrap().clone());
         self.frame_count
     }
 


### PR DESCRIPTION
if we want to replay the existing display list.